### PR TITLE
Add CC BY-NC 4.0 research-only license + README banner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,59 +6,75 @@ Copyright (c) 2026 Emergence AI. All rights reserved.
 This repository (including all documentation, agent profiles, landmark
 descriptions, tool catalogs, governance documents, datasets, metrics,
 and any other content) is licensed to the public under the
-**Creative Commons Attribution-NonCommercial-NoDerivatives 4.0
-International License (CC BY-NC-ND 4.0)**.
+**Creative Commons Attribution-NonCommercial 4.0 International
+License (CC BY-NC 4.0)**.
 
 You are free to:
-  - **Share** — copy and redistribute the material in any medium or format
-    for non-commercial research and educational purposes, with attribution
-    to Emergence AI.
+  - **Share** — copy and redistribute the material in any medium or
+    format for non-commercial research and educational purposes.
+  - **Adapt** — remix, transform, and build upon the material for
+    non-commercial research and educational purposes.
 
 Under the following terms:
-  - **Attribution (BY)** — You must give appropriate credit to Emergence AI,
-    provide a link to this repository, and indicate if changes were made.
-  - **NonCommercial (NC)** — You may not use the material for commercial
-    purposes. This includes, without limitation: selling or sublicensing
-    the material, incorporating it into a commercial product or service,
-    or using the tool-call dataset (or any portion of this repository) to
-    train, fine-tune, evaluate, or benchmark commercial AI models.
-  - **NoDerivatives (ND)** — If you remix, transform, or build upon the
-    material, you may not distribute the modified material.
+  - **Attribution (BY)** — You **must** give appropriate credit to
+    Emergence AI, provide a link to this repository
+    (https://github.com/EmergenceAI/Emergence-World), and indicate if
+    changes were made. You may do so in any reasonable manner, but not
+    in any way that suggests Emergence AI endorses you or your use.
+    For academic and research use, please also include the citation
+    block provided in the README.
+  - **NonCommercial (NC)** — You may not use the material for
+    commercial purposes. This includes, without limitation: selling or
+    sublicensing the material, incorporating it into a commercial
+    product or service, or using the tool-call dataset (or any portion
+    of this repository) to train, fine-tune, evaluate, or benchmark
+    commercial AI models.
 
-No additional restrictions — You may not apply legal terms or technological
-measures that legally restrict others from doing anything the license
-permits.
+No additional restrictions — You may not apply legal terms or
+technological measures that legally restrict others from doing
+anything the license permits.
 
 Notices:
-  - You do not have to comply with the license for elements of the material
-    in the public domain or where your use is permitted by an applicable
-    exception or limitation.
+  - You do not have to comply with the license for elements of the
+    material in the public domain or where your use is permitted by an
+    applicable exception or limitation.
   - No warranties are given. The license may not give you all of the
-    permissions necessary for your intended use. For example, other rights
-    such as publicity, privacy, or moral rights may limit how you use the
-    material.
+    permissions necessary for your intended use. For example, other
+    rights such as publicity, privacy, or moral rights may limit how
+    you use the material.
 
-Commercial Use, Derivative Works, and Model Training
-----------------------------------------------------
-Any use outside the scope of CC BY-NC-ND 4.0 — including commercial use,
-the creation and distribution of derivative works, or the use of any
-content or data in this repository to train, fine-tune, evaluate, or
-benchmark AI/ML models for any commercial purpose — requires prior
-written permission from Emergence AI.
+Attribution Format
+------------------
+When citing, redistributing, or adapting any portion of this
+repository, please include attribution substantially in the
+following form:
+
+    "Emergence World" by Emergence AI, licensed under CC BY-NC 4.0.
+    Source: https://github.com/EmergenceAI/Emergence-World
+
+For academic publications, please use the BibTeX citation provided in
+the repository README.
+
+Commercial Use and Model Training
+---------------------------------
+Any use outside the scope of CC BY-NC 4.0 — including commercial use
+of any kind, or the use of any content or data in this repository to
+train, fine-tune, evaluate, or benchmark AI/ML models for any
+commercial purpose — requires prior written permission from
+Emergence AI.
 
 For licensing inquiries, please contact: world@emergence.ai
 
 Full License Text
 -----------------
 The full legal code of the Creative Commons
-Attribution-NonCommercial-NoDerivatives 4.0 International License is
-available at:
+Attribution-NonCommercial 4.0 International License is available at:
 
-    https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+    https://creativecommons.org/licenses/by-nc/4.0/legalcode
 
 A human-readable summary is available at:
 
-    https://creativecommons.org/licenses/by-nc-nd/4.0/
+    https://creativecommons.org/licenses/by-nc/4.0/
 
-By using, copying, or redistributing any portion of this repository, you
-agree to be bound by the terms above.
+By using, copying, redistributing, or adapting any portion of this
+repository, you agree to be bound by the terms above.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,64 @@
+Emergence World — Research-Only License Notice
+================================================
+
+Copyright (c) 2026 Emergence AI. All rights reserved.
+
+This repository (including all documentation, agent profiles, landmark
+descriptions, tool catalogs, governance documents, datasets, metrics,
+and any other content) is licensed to the public under the
+**Creative Commons Attribution-NonCommercial-NoDerivatives 4.0
+International License (CC BY-NC-ND 4.0)**.
+
+You are free to:
+  - **Share** — copy and redistribute the material in any medium or format
+    for non-commercial research and educational purposes, with attribution
+    to Emergence AI.
+
+Under the following terms:
+  - **Attribution (BY)** — You must give appropriate credit to Emergence AI,
+    provide a link to this repository, and indicate if changes were made.
+  - **NonCommercial (NC)** — You may not use the material for commercial
+    purposes. This includes, without limitation: selling or sublicensing
+    the material, incorporating it into a commercial product or service,
+    or using the tool-call dataset (or any portion of this repository) to
+    train, fine-tune, evaluate, or benchmark commercial AI models.
+  - **NoDerivatives (ND)** — If you remix, transform, or build upon the
+    material, you may not distribute the modified material.
+
+No additional restrictions — You may not apply legal terms or technological
+measures that legally restrict others from doing anything the license
+permits.
+
+Notices:
+  - You do not have to comply with the license for elements of the material
+    in the public domain or where your use is permitted by an applicable
+    exception or limitation.
+  - No warranties are given. The license may not give you all of the
+    permissions necessary for your intended use. For example, other rights
+    such as publicity, privacy, or moral rights may limit how you use the
+    material.
+
+Commercial Use, Derivative Works, and Model Training
+----------------------------------------------------
+Any use outside the scope of CC BY-NC-ND 4.0 — including commercial use,
+the creation and distribution of derivative works, or the use of any
+content or data in this repository to train, fine-tune, evaluate, or
+benchmark AI/ML models for any commercial purpose — requires prior
+written permission from Emergence AI.
+
+For licensing inquiries, please contact: world@emergence.ai
+
+Full License Text
+-----------------
+The full legal code of the Creative Commons
+Attribution-NonCommercial-NoDerivatives 4.0 International License is
+available at:
+
+    https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+
+A human-readable summary is available at:
+
+    https://creativecommons.org/licenses/by-nc-nd/4.0/
+
+By using, copying, or redistributing any portion of this repository, you
+agree to be bound by the terms above.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@
 
 > ## 🔬 Research-Only License
 >
-> This repository — including all documentation, agent profiles, landmarks, tool catalogs, governance documents, and datasets — is released **for non-commercial research and educational use only** under [**CC BY-NC-ND 4.0**](https://creativecommons.org/licenses/by-nc-nd/4.0/).
+> This repository — including all documentation, agent profiles, landmarks, tool catalogs, governance documents, and datasets — is released **for non-commercial research and educational use only** under [**CC BY-NC 4.0**](https://creativecommons.org/licenses/by-nc/4.0/).
 >
-> **You may:** read, cite, and share the material with attribution to Emergence AI.
-> **You may not:** use it commercially, redistribute modified versions, or use any content or dataset to train, fine-tune, evaluate, or benchmark AI/ML models for commercial purposes.
+> **You may:** read, cite, share, and adapt the material for non-commercial research, **provided you give clear attribution** to Emergence AI (link this repository and indicate any changes).
+> **You may not:** use the material for any commercial purpose, or use any content or dataset to train, fine-tune, evaluate, or benchmark AI/ML models for commercial purposes.
 >
-> All content is proprietary to Emergence AI. For commercial licensing, derivative works, or model-training inquiries, contact [world@emergence.ai](mailto:world@emergence.ai). See [LICENSE](LICENSE) for full terms.
+> All content is proprietary to Emergence AI. For commercial licensing or model-training inquiries, contact [world@emergence.ai](mailto:world@emergence.ai). See [LICENSE](LICENSE) for the full terms and the required attribution format.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@
 
 ---
 
+> ## 🔬 Research-Only License
+>
+> This repository — including all documentation, agent profiles, landmarks, tool catalogs, governance documents, and datasets — is released **for non-commercial research and educational use only** under [**CC BY-NC-ND 4.0**](https://creativecommons.org/licenses/by-nc-nd/4.0/).
+>
+> **You may:** read, cite, and share the material with attribution to Emergence AI.
+> **You may not:** use it commercially, redistribute modified versions, or use any content or dataset to train, fine-tune, evaluate, or benchmark AI/ML models for commercial purposes.
+>
+> All content is proprietary to Emergence AI. For commercial licensing, derivative works, or model-training inquiries, contact [world@emergence.ai](mailto:world@emergence.ai). See [LICENSE](LICENSE) for full terms.
+
+---
+
 ## What is Emergence World?
 
 Emergence World is a long-horizon experiment that places autonomous AI agents into a persistent, simulated world — and observes what emerges. Each agent has a unique personality, profession, memory, and goals. They navigate a shared physical space, interact with 120+ tools, govern themselves through a constitution they can amend, earn and spend a digital currency (ComputeCredits), form relationships, write blogs, build alliances, and evolve — all without human scripting.


### PR DESCRIPTION
## Summary
- Adds a `LICENSE` file releasing the repo under **CC BY-NC 4.0** with an explicit Emergence AI carve-out forbidding commercial use and use of any content or dataset to train, fine-tune, evaluate, or benchmark commercial AI/ML models.
- Adds a **research-only license banner** directly under the README header so terms are visible to every visitor at a glance.
- Makes the attribution requirement explicit in both the LICENSE and the banner, and provides a recommended attribution string for copy-paste use.

## Why
The repo (docs, agent profiles, landmarks, tool catalog, governance docs, and the forthcoming tool-call dataset) needs to stay proprietary to Emergence AI while still being usable for academic citation and research. CC BY-NC is the closest canned license to that intent — it allows non-commercial remixing and adaptation (so researchers can annotate, translate, or build derived datasets) while requiring attribution. The explicit AI-training carve-out closes the well-known fuzziness in CC's "non-commercial" definition.

## Companion PR
Sibling PR #12 lands the identical commit on `main` so the two branches stay in sync on licensing.

## Test plan
- [ ] Confirm `LICENSE` renders on GitHub's repo header and the license picker recognizes it as CC BY-NC-4.0
- [ ] Confirm the README banner renders correctly (blockquote + heading) on the GitHub README view
- [ ] Legal review of the carve-out language before relying on it in any dispute

🤖 Generated with [Claude Code](https://claude.com/claude-code)